### PR TITLE
Update: deploy consul with Traefik (for swarm)

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -2,6 +2,26 @@
 version: '{{ traefik_compose_version }}'
 
 services:
+{% if traefik_consul_enable %}
+  consul:
+    image: consul:1.6
+    command: agent -server -bootstrap-expect=1
+    volumes:
+      - consul-data:/consul/data
+    environment:
+      - CONSUL_LOCAL_CONFIG={"datacenter":"pn1","server":true}
+      - CONSUL_BIND_INTERFACE=eth0
+      - CONSUL_CLIENT_INTERFACE=eth0
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+      restart_policy:
+        condition: on-failure
+    networks:
+      - traefik_lan
+{% endif %}
   traefik:
     image: {{ traefik_image }}:{{ traefik_version }}
     ports:
@@ -24,6 +44,7 @@ services:
 {% endif %}
     networks:
       - {{ traefik_docker_network }}
+      - traefik_lan
 {% if traefik_dashboard_enable %}
     labels:
       - "traefik.port={{ traefik_dashboard_entrypoint_port }}"
@@ -35,15 +56,18 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - {{ traefik_directory }}/traefik.toml:/traefik.toml
-      - {{ traefik_directory }}/conf.d:/conf.d
+      # - {{ traefik_directory }}/conf.d:/conf.d
 {% if traefik_acme_enable %}
+{% if not traefik_consul_enable %}
       - {{ traefik_directory }}/acme.json:/acme.json
+{% endif %}
 {% endif %}
 {% if not traefik_use_swarm %}
     container_name: traefik
     restart: always
 {% else %}
     deploy:
+      mode: global
 {% if traefik_dashboard_enable %}
       labels:
         - "traefik.port={{ traefik_dashboard_entrypoint_port }}"
@@ -58,5 +82,6 @@ services:
 {% endif %}
 
 networks:
+  traefik_lan:
   {{ traefik_docker_network }}:
     external: true

--- a/templates/traefik.toml.j2
+++ b/templates/traefik.toml.j2
@@ -30,9 +30,9 @@ defaultEntryPoints = ["https","http"]
 entryPoint = "traefik"
 {% endif %}
 
-[file]
-directory = "/conf.d"
-watch = true
+#[file]
+#directory = "/conf.d"
+#watch = true
 
 {% if traefik_docker_enable %}
 [docker]

--- a/templates/traefik.toml.j2
+++ b/templates/traefik.toml.j2
@@ -48,7 +48,11 @@ swarmMode = true
 {% if traefik_acme_enable %}
 [acme]
 email = "{{ traefik_acme_email }}"
+{% if traefik_consul_enable %}
+storage = "traefik/acme/account"
+{% else %}
 storage = "acme.json"
+{% endif %}
 entryPoint = "https"
 {% if traefik_acme_use_staging_ca %}
 caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"


### PR DESCRIPTION
- for let's encrypt storage

Related: pngmbh/issues#428