### PR TITLE
Prep for: 2.0.0-pn0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,10 +10,7 @@ traefik_log_level: "WARNING"
 traefik_image: "traefik"
 
 # Main configuration
-traefik_entrypoint_http_port: 80
-traefik_entrypoint_http_redirect_to_https: true
-traefik_entrypoint_https_port: 443
-traefik_docker_network: "traefik"
+traefik_docker_network: "public"
 
 # Dashboard
 traefik_dashboard_enable: true
@@ -23,7 +20,6 @@ traefik_dashboard_basicauth_enable: true
 traefik_dashboard_basicauth_users: []
 
 # Docker
-traefik_docker_enable: true
 # traefik_docker_domain: "mydomain.org" (defaults to inventory_hostname)
 traefik_docker_expose_by_default: false
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,6 +3,7 @@
   template:
     src: traefik.toml.j2
     dest: "{{ traefik_directory }}/traefik.toml"
+  when: not traefik_consul_enable
   notify: restart traefik
 
 - name: Render docker-compose config
@@ -15,7 +16,7 @@
     path: "{{ traefik_directory }}/acme.json"
     state: touch
     mode: 0600
-  when: traefik_acme_enable
+  when: traefik_acme_enable and not traefik_consul_enable
   changed_when: false
 
 - name: Pull Docker image

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -26,17 +26,17 @@ services:
     image: {{ traefik_image }}:{{ traefik_version }}
     ports:
 {% if traefik_use_swarm %}
-      - target: {{ traefik_entrypoint_http_port }}
+      - target: 80
         published: 80
         protocol: tcp
         mode: host
-      - target: {{ traefik_entrypoint_https_port }}
+      - target: 443
         published: 443
         protocol: tcp
         mode: host
 {% else %}
-      - "{{ traefik_entrypoint_http_port }}:80"
-      - "{{ traefik_entrypoint_https_port }}:443"
+      - "80:80"
+      - "443:443"
 {% endif %}
 {% if traefik_dashboard_enable and not traefik_use_swarm %}
     expose:
@@ -56,7 +56,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - {{ traefik_directory }}/traefik.toml:/traefik.toml
-      # - {{ traefik_directory }}/conf.d:/conf.d
 {% if traefik_acme_enable %}
 {% if not traefik_consul_enable %}
       - {{ traefik_directory }}/acme.json:/acme.json

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -3,16 +3,81 @@ version: '{{ traefik_compose_version }}'
 
 services:
 {% if traefik_consul_enable %}
+  traefik_init:
+    image: {{ traefik_image }}:{{ traefik_version }}
+    networks:
+      - traefik_lan
+    deploy:
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      - consul
+    command:
+      - "storeconfig"
+{% if traefik_dashboard_enable %}
+      - "--api"
+      - "--api.entrypoint=traefik"
+      - "--entrypoints=Name:traefik Address::{{ traefik_dashboard_entrypoint_port }} Auth.Basic.Users:{{ traefik_dashboard_basicauth_users[0] }}"
+{% endif %}
+      - "--retry"
+      - "--loglevel={{ traefik_log_level }}"
+{% if traefik_debug_enable %}
+      - "--debug"
+{% endif %}
+      - "--entrypoints=Name:http Address::80 Redirect.EntryPoint:https"
+      - "--entrypoints=Name:https Address::443 TLS"
+      - "--defaultentrypoints=http,https"
+      - "--docker"
+      - "--docker.endpoint=unix:///var/run/docker.sock"
+      - "--docker.domain={{ traefik_docker_domain | default(inventory_hostname) }}"
+      - "--docker.watch=true"
+{% if traefik_docker_expose_by_default %}
+      - "--docker.exposedbydefault"
+{% endif %}
+{% if traefik_use_swarm and traefik_swarm_mode %}
+      - "--docker.swarmmode"
+{% endif %}
+{% if traefik_acme_enable %}
+      - "--acme"
+      - "--acme.email={{ traefik_acme_email }}"
+{% if traefik_consul_enable %}
+      - "--acme.storage=traefik/acme/account"
+{% else %}
+      - "--acme.storage=acme.json"
+{% endif %}
+      - "--acme.entrypoint=https"
+{% if traefik_acme_use_staging_ca %}
+      - "--acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+{% endif %}
+{% if traefik_acme_autocreate_from_host %}
+      - "--acme.onhostrule"
+{% endif %}
+      - "--acme.httpchallenge"
+      - "--acme.httpchallenge.entrypoint=http"
+{% endif %}
+      - "--consul"
+      - "--consul.endpoint=consul:8500"
+      - "--consul.prefix=traefik"
   consul:
     image: consul:1.6
-    command: agent -server -bootstrap-expect=1
+    command:
+      - "agent"
+      - "-server"
+      - "-ui"
+      - "-node=traefik-consul"
+      - "-bootstrap-expect=1"
+      - "-log-level=debug"
+      - "-client=0.0.0.0"
     volumes:
       - consul-data:/consul/data
     environment:
-      - CONSUL_LOCAL_CONFIG={"datacenter":"pn1","server":true}
+      - CONSUL_LOCAL_CONFIG={"datacenter":"pn1"}
       - CONSUL_BIND_INTERFACE=eth0
-      - CONSUL_CLIENT_INTERFACE=eth0
     deploy:
+      labels:
+        traefik.frontend.auth.basic.users: "{{ traefik_dashboard_basicauth_users[0] }}"
+        traefik.port: "8500"
+        traefik.enable: "true"
       replicas: 1
       placement:
         constraints:
@@ -24,6 +89,18 @@ services:
 {% endif %}
   traefik:
     image: {{ traefik_image }}:{{ traefik_version }}
+{% if traefik_consul_enable %}
+    command:
+      - "--consul"
+      - "--consul.endpoint=consul:8500"
+      - "--consul.prefix=traefik"
+{% if traefik_consul_watch %}
+      - "--consul.watch"
+{% endif %}
+    depends_on:
+      - traefik_init
+      - consul
+{% endif %}
     ports:
 {% if traefik_use_swarm %}
       - target: 80
@@ -55,9 +132,9 @@ services:
 {% endif %}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+{% if not traefik_consul_enable %}
       - {{ traefik_directory }}/traefik.toml:/traefik.toml
 {% if traefik_acme_enable %}
-{% if not traefik_consul_enable %}
       - {{ traefik_directory }}/acme.json:/acme.json
 {% endif %}
 {% endif %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -85,3 +85,8 @@ networks:
   traefik_lan:
   {{ traefik_docker_network }}:
     external: true
+
+{% if traefik_consul_enable %}
+volumes:
+  consul-data:
+{% endif %}

--- a/templates/traefik.toml.j2
+++ b/templates/traefik.toml.j2
@@ -6,13 +6,11 @@ defaultEntryPoints = ["https","http"]
 
 [entryPoints]
   [entryPoints.http]
-  address = ":{{ traefik_entrypoint_http_port }}"
-{% if traefik_entrypoint_http_redirect_to_https %}
+  address = ":80"
     [entryPoints.http.redirect]
-{% endif %}
     entryPoint = "https"
   [entryPoints.https]
-  address = ":{{ traefik_entrypoint_https_port }}"
+  address = ":443"
     [entryPoints.https.tls]
 {% if traefik_dashboard_enable %}
   [entryPoints.traefik]
@@ -30,11 +28,6 @@ defaultEntryPoints = ["https","http"]
 entryPoint = "traefik"
 {% endif %}
 
-#[file]
-#directory = "/conf.d"
-#watch = true
-
-{% if traefik_docker_enable %}
 [docker]
 endpoint = "unix:///var/run/docker.sock"
 domain = "{{ traefik_docker_domain | default(inventory_hostname) }}"
@@ -42,7 +35,6 @@ watch = true
 exposedByDefault = {{ traefik_docker_expose_by_default | lower }}
 {% if traefik_use_swarm and traefik_swarm_mode %}
 swarmMode = true
-{% endif %}
 {% endif %}
 
 {% if traefik_acme_enable %}


### PR DESCRIPTION
- BC breaks
   - removed `conf.d`
   - ports for http and https are no longer configurable
   - http to https always redirects
   - traefik's public network is `public`

- Fixes:
   - declare volume for consul (broken in `v1.0.0-pn9`)