### PR TITLE
Update: support forward auth for dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,39 @@
 Traefik (in Docker) role for Ansible
 ====
 
+## Feature highlights
+
+ - supports the latest Traefik v1.x (e.g. v1.7)
+ - authentication
+    - basic auth
+    - forward auth
+ - enabling Traefik's dashboard
+ - works with Docker (stand-alone/docker-compose) and Docker Swarm
+ - potentially consul integration (**does not** install consul)
+
 #### Dependencies
 
 - Assumes Docker and Docker Compose are installed on the host
+- Ansible requires:
+  - `pip install jsondiff`
+  - `pip install pyyaml`
+  - manage Python deps with `traefik_manage_ansible_dependencies (bool)`
 
 #### Usage
+
+Installation:
+
+```
+$ ansible-galaxy install pngmbh.ansible_traefik_docker
+```
+
+Or add it to your `requirements.yml`:
+
+```
+- name: pngmbh.ansible_traefik_docker
+  src: https://github.com/pngmbh/ansible-traefik-docker
+  version: GIT-TAG-HERE
+```
 
 Create a playbook (`traefik.yml`) from this role:
 
@@ -14,9 +42,13 @@ Create a playbook (`traefik.yml`) from this role:
 - name: Install and configure Traefik reverse-proxy
   hosts: <your host group or individual host>
   roles:
-    - role: roles/traefik
+    - role: pngmbh.ansible_docker_traefik
       traefik_acme_email: "user@mydomain.org"
       traefik_dashboard_basicauth_users: ["user:$apr1$somehash"]
 ```
 
 For a list of all options, see [defaults/main.yml](defaults/main.yml).
+
+## About the author
+
+This is a fork, but it diverged and is actively tested and maintained here. Come check us out: [Planetary Quantum GmbH](https://www.planetary-quantum.com) :rocket:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ traefik_dashboard_entrypoint_port: 8080
 traefik_dashboard_subdomain: "traefik"
 traefik_dashboard_basicauth_enable: true
 traefik_dashboard_basicauth_users: []
+traefik_dashboard_fwdauth_server: ""
 
 # Docker
 # traefik_docker_domain: "mydomain.org" (defaults to inventory_hostname)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,12 +16,13 @@ traefik_docker_network: "public"
 traefik_dashboard_enable: true
 traefik_dashboard_entrypoint_port: 8080
 traefik_dashboard_subdomain: "traefik"
+traefik_dashboard_fqdn: "{{ traefik_dashboard_subdomain }}.{{ traefik_docker_domain }}"
 traefik_dashboard_basicauth_enable: true
 traefik_dashboard_basicauth_users: []
 traefik_dashboard_fwdauth_server: ""
 
 # Docker
-# traefik_docker_domain: "mydomain.org" (defaults to inventory_hostname)
+traefik_docker_domain: "{{ inventory_hostname }}"
 traefik_docker_expose_by_default: false
 
 # Enable automatic certificates from Let's Encrypt

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,3 +45,7 @@ traefik_use_swarm: false
 traefik_swarm_mode: false
 traefik_swarm_network_driver: "overlay"
 traefik_swarm_network_attachable: true
+
+# Whatever Ansible needs to execute this role
+# If you're doing it otherwise, you can set this to false
+traefik_manage_ansible_dependencies: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,16 @@
 ---
+- name: Labels include fwd auth
+  set_fact:
+    traefik_dashboard_labels: "{{ _traefik_dashboard_labels + _traefik_dashboard_fwdauth_labels }}"
+  when:
+    - traefik_dashboard_fwdauth_server|length > 0
+
+- name: Labels don't include fwd auth
+  set_fact:
+    traefik_dashboard_labels: "{{ _traefik_dashboard_labels }}"
+  when:
+    - traefik_dashboard_fwdauth_server|length == 0
+
 - name: Render traefik config
   template:
     src: traefik.toml.j2

--- a/tasks/guard.yml
+++ b/tasks/guard.yml
@@ -1,0 +1,43 @@
+---
+- name: Ensure only basic auth or fwd auth are enabled
+  block:
+    - name: Basic auth is enabled, no fwd auth server is configured
+      block:
+        - name: Test [basic auth, dashboard is enabled]
+          assert:
+            that:
+              - traefik_dashboard_enable
+            fail_msg: "Please enable dashboard if you want basic auth for it"
+            quiet: true
+        - name: Test [basic auth enabled]
+          assert:
+            that:
+              - traefik_dashboard_fwdauth_server|length == 0
+            fail_msg: "You tried to enable basic auth AND fwd auth (hint: unconfigured traefik_dashboard_fwdauth_server)"
+            quiet: true
+        - name: Test [basic auth users are set]
+          assert:
+            that:
+              - traefik_dashboard_basicauth_users|length > 0
+            fail_msg: "You enabled basic auth without users (hint: configure traefik_dashboard_basicauth_users)"
+            quiet: true
+      when:
+        - traefik_dashboard_basicauth_enable
+
+    - name: Fwd auth server is configured correctly
+      block:
+        - name: Test [fwd auth, dashboard is enabled]
+          assert:
+            that:
+              - traefik_dashboard_enable
+            fail_msg: "Please enable dashboard if you want forward auth for it"
+            quiet: true
+        - name: Test [fwd auth is configured]
+          assert:
+            that:
+              - traefik_dashboard_basicauth_users|length == 0
+              - not traefik_dashboard_basicauth_enable
+            fail_msg: "Please remove config for basic auth and enable dashboard"
+            quiet: true
+      when:
+        - traefik_dashboard_fwdauth_server|length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,7 @@
         name:
           - jsondiff==1.2.0
           - pyyaml==5.2
+      when: traefik_manage_ansible_dependencies
 
     - name: Create traefik docker network (Swarm)
       docker_network:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include: guard.yml
+
 - include: install.yml
 
 - include: configure.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,12 @@
 ---
-traefik_dashboard_labels:
+_traefik_dashboard_labels:
   - "traefik.port={{ traefik_dashboard_entrypoint_port }}"
   - "traefik.docker.network={{ traefik_docker_network }}"
   - "traefik.backend=traefik"
   - "traefik.frontend.rule=Host:{{ traefik_dashboard_subdomain }}.{{ traefik_docker_domain | default(inventory_hostname) }}"
   - "traefik.enable=true"
+
+_traefik_dashboard_fwdauth_labels:
+  - "traefik.frontend.auth.forward.address: {{ traefik_dashboard_fwdauth_server }}"
+  - "traefik.frontend.auth.forward.authResponseHeaders=X-Auth-User,X-Auth-Group"
+  - "traefik.frontend.auth.forward.trustForwardHeader=true"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@ _traefik_dashboard_labels:
   - "traefik.port={{ traefik_dashboard_entrypoint_port }}"
   - "traefik.docker.network={{ traefik_docker_network }}"
   - "traefik.backend=traefik"
-  - "traefik.frontend.rule=Host:{{ traefik_dashboard_subdomain }}.{{ traefik_docker_domain | default(inventory_hostname) }}"
+  - "traefik.frontend.rule=Host:{{ traefik_dashboard_fqdn }}"
   - "traefik.enable=true"
 
 _traefik_dashboard_fwdauth_labels:


### PR DESCRIPTION
## forward auth / external authentication

 - enable with `traefik_dashboard_fwdauth_server` (`https://fqdn`)
 - append forward auth labels to traefik (dashboard) service when necessary
 - added guards to ensure things are configured correctly (e.g. basic auth or forward auth)

## traefik dashboard

 - introduce `{{ traefik_dashboard_fqdn }}`
 - allow setting the complete fqdn of the traefik dashboard
 - defaults to `{{ traefik_dashboard_subdomain }}.{{ inventory_hostname }}`