### PR TITLE
Fix: remove pip install from swarm setup branch

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,12 +8,6 @@
 
 - name: Swarm Setup
   block:
-    - name: Install dependencies
-      pip:
-        name:
-          - jsondiff==1.2.0
-          - pyyaml==5.2
-
     - name: Create traefik docker network (Swarm)
       docker_network:
         name: "{{ traefik_docker_network }}"


### PR DESCRIPTION
Doesn't work on flatcar (which needs to set `executable:`) and also
this is generally already installed on swarm nodes anyway.